### PR TITLE
Fix MatrixDataPoint types

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -21,8 +21,10 @@ export interface MatrixControllerDatasetOptions<TType extends ChartType>
 }
 
 export interface MatrixDataPoint {
-  x: number,
-  y: number,
+  x: number | string;
+  y: number | string;
+  d?: number | string;
+  v: number;
 }
 
 declare module 'chart.js' {


### PR DESCRIPTION
Based on the `chartjs-chart-matrix` examples, there should be `v` and optional `d` properties in the `MatrixDataPoint` type. Also, `x` and `y` can be of string type.