### PR TITLE
chore(deps): group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary

- Group dependabot npm dev-dependency bumps and github-actions bumps into single weekly PRs instead of one PR per dependency, matching the grouping being rolled out across all kurkle chart.js repos.
- Checked the README badge block against the reference order (npm version, github release, bundlephobia min size, Sonar quality gate, Sonar coverage, documentation link, github license) — it already matches exactly, so README is untouched.
- Did not add an `engines` field to package.json — matrix ships browser code, and `engines` would needlessly constrain installers for a browser library.

## Test plan
- [x] `npm run lint`
- [x] YAML validated (`dependabot.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)