### PR TITLE
chore(deps): ignore TypeScript major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+    ignore:
+      # @astrojs/check requires typescript ^5 || ^6, so TS 7 breaks npm ci
+      # with ERESOLVE and stalls the whole dev-dependencies group.
+      # Remove this once @astrojs/check supports TypeScript 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

The grouped npm dev-dependencies PR (#426) is stuck on a TypeScript 7 bump. Root cause: `npm ci` itself fails with ERESOLVE, not a type error — `@astrojs/check@0.9.10` (latest published) declares `peerDependencies.typescript: "^5.0.0 || ^6.0.0"`, which rejects 7. No upstream fix is available yet.

- Added an `ignore` rule for `typescript` major-version bumps only, with a comment explaining why and when to remove it.
- Minor/patch TypeScript updates still flow through the `dev-dependencies` group normally.
- Did not move `typescript` out of the group (would just produce a separate, permanently-red PR) or force TS 7 via `overrides` (would likely break `@astrojs/check`'s use of the TS compiler API rather than just silencing the ERESOLVE).

## Test plan
- [x] `npm run lint`
- [x] YAML validated (`dependabot.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)