### PR TITLE
ci: pass SONAR_TOKEN explicitly, scan workflow files with Sonar

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -13,7 +13,8 @@ jobs:
     with:
       fetch-depth: 0
       run-audit-signatures: true
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -13,7 +13,8 @@ jobs:
     with:
       fetch-depth: 1
       run-audit-signatures: false
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   compressed-size:
     runs-on: ubuntu-latest

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,8 +5,15 @@ sonar.organization=kurkle
 sonar.projectName=chartjs-chart-matrix
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=src/
+sonar.sources=src/,.github/workflows
 sonar.exclusions=**/*.test.*,
 sonar.tests=test/
 
 sonar.javascript.lcov.reportPaths=coverage/chrome/lcov.info,coverage/firefox/lcov.info,coverage/unit/lcov.info
+
+# The floating v1 tag is deliberate: it is how a fix in kurkle/configs reaches
+# every repository without a pull request in each one. Pinning a commit SHA
+# would defeat that mechanism.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/*.yml


### PR DESCRIPTION
## Summary

- Replace `secrets: inherit` with an explicit `secrets: { SONAR_TOKEN: ... }` mapping in both `pr-ci.yml` and `main-ci.yml`, now that `kurkle/configs@v1.3.0` declares `SONAR_TOKEN` by name in `shared-ci.yml`'s `workflow_call` trigger. `GITHUB_TOKEN` needs no passing — the shared workflow uses the ambient `github.token` for it.
- Add `.github/workflows` to `sonar.sources` so the workflow files themselves get scanned.
- Add a targeted ignore for `githubactions:S7637` (unpinned action ref) scoped to `.github/workflows/*.yml`, since the shared workflow is deliberately referenced via the floating `@v1` tag — that's how a fix in `kurkle/configs` reaches every repo without a PR in each one; pinning to a commit SHA would defeat that.

## Test plan
- [x] `npm run lint`
- [x] YAML validated (`pr-ci.yml`, `main-ci.yml`)
- [ ] This PR's own Sonar run: passes, actually analyzes the workflow files, and neither S7635 nor S7637 fires (see Checks tab / SonarCloud)

🤖 Generated with [Claude Code](https://claude.com/claude-code)