### PR TITLE
fix(test): give fixture suites unique names

### DIFF
--- a/test/specs/fixtures.spec.js
+++ b/test/specs/fixtures.spec.js
@@ -1,3 +1,5 @@
-describe('auto', jasmine.fixtures('anchor'))
-describe('auto', jasmine.fixtures('border'))
-describe('auto', jasmine.fixtures('scales'))
+describe('fixtures', () => {
+  describe('anchor', jasmine.fixtures('anchor'))
+  describe('border', jasmine.fixtures('border'))
+  describe('scales', jasmine.fixtures('scales'))
+})


### PR DESCRIPTION
## Summary

The grouped npm `dev-dependencies` dependabot PR (#428) fails on `shared-ci / CI`. Root cause: it bumps `jasmine` 6.3.0→7.0.0 and `jasmine-core` 6.3.0→7.0.2, and jasmine 7 enforces unique suite names by default. `test/specs/fixtures.spec.js` had three top-level suites all named `"auto"`, which 6.x tolerated silently. Under 7 the karma fixture run fails outright in both browsers: `Uncaught Error: Duplicate suite name "auto" found in top suite`, 0 of 0 tests executed.

- Nest the fixtures under one outer `"fixtures"` suite with a unique name per fixture directory (`anchor`/`border`/`scales`), matching `chartjs-chart-treemap`'s existing structure — same fix, and brings matrix in line with the rest of the unification.
- Checked sankey, treemap, gradient, and autocolors — none have this duplicate-name pattern, so this is matrix-only.

## Test plan
- [x] `npm run lint`
- [x] `npm test` with the current jasmine-core 6.3.0 — 20 of 20 fixture/controller specs executed and passed (not just exit code 0)
- [x] `npm test` with `jasmine@7.0.0`/`jasmine-core@7.0.2`/`karma-jasmine-html-reporter@2.3.0` installed ad hoc (`npm install --no-save`, reverted with `npm ci` afterward) — 20 of 20 fixture/controller specs + 29 of 29 unit specs executed and passed on both Chrome and Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)