### PR TITLE
ci: install dependencies with --ignore-scripts

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: 24
           cache: npm
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
       - name: Build
         run: npm run build
       - name: Release

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           cache: npm
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
       - name: Build
         run: npm run build
       - name: Compressed size
@@ -37,3 +37,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: "./dist/*.{js,cjs}"
           build-script: npm run build
+          install-script: npm ci --ignore-scripts


### PR DESCRIPTION
## Summary

Dependency lifecycle scripts are a common malware distribution vector in npm today. This repo's own workflow jobs installed dependencies without `--ignore-scripts`:

- `main-ci.yml`'s `release` job
- `pr-ci.yml`'s `compressed-size` job, including `preactjs/compressed-size-action`'s own internal install (it installs and builds both the PR branch and the base branch itself to diff them) — passed `install-script: npm ci --ignore-scripts` so that install is protected too

The shared workflow (`kurkle/configs/.github/workflows/shared-ci.yml@v1`) gets its own default separately through configs and is untouched here.

The only install-script packages in this dependency tree are `@swc/core` and `esbuild`; both get their native binaries from optional platform packages, not postinstall, so skipping lifecycle scripts doesn't affect them.

## Test plan
- [x] `npm run lint`
- [x] YAML validated (`main-ci.yml`, `pr-ci.yml`)
- [x] Fresh `npm clean-install --ignore-scripts` locally, then lint/typecheck/build/full test suite (unit, karma fixtures, browser-module, node-commonjs/module integration) all pass unchanged
- [ ] This PR's own CI, including `compressed-size` posting a real size report (see Checks tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)