### PR TITLE
docs(readme): reorder sections and add Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # chartjs-chart-matrix
 
-[Chart.js](https://www.chartjs.org/) **v3+, v4+** module for creating matrix charts
-
 [![npm](https://img.shields.io/npm/v/chartjs-chart-matrix.svg)](https://www.npmjs.com/package/chartjs-chart-matrix)
 [![release](https://img.shields.io/github/release/kurkle/chartjs-chart-matrix.svg?style=flat-square)](https://github.com/kurkle/chartjs-chart-matrix/releases/latest)
 ![npm bundle size](https://img.shields.io/bundlephobia/min/chartjs-chart-matrix.svg)
@@ -10,13 +8,26 @@
 [![documentation](https://img.shields.io/static/v1?message=Documentation&color=informational)](https://chartjs-chart-matrix.pages.dev)
 ![GitHub](https://img.shields.io/github/license/kurkle/chartjs-chart-matrix.svg)
 
+[Chart.js](https://www.chartjs.org/) **v3+, v4+** module that adds a matrix chart type, plotting data as a grid of colored, sized rectangles — useful for heatmaps, confusion matrices, calendars and other value-by-coordinate data, for anyone already charting with Chart.js.
+
 ## Example
 
 ![Matrix Example Image](matrix.png)
 
-## Documentation
+## Installation
 
-You can find documentation for chartjs-chart-matrix at [https://chartjs-chart-matrix.pages.dev/](https://chartjs-chart-matrix.pages.dev/).
+### npm
+
+```bash
+> npm install chartjs-chart-matrix
+```
+
+### CDN
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@3"></script>
+```
 
 ## Quickstart
 
@@ -64,7 +75,11 @@ You can find documentation for chartjs-chart-matrix at [https://chartjs-chart-ma
 </body>
 ```
 
-This simple example is also available online in the documentation: https://chartjs-chart-matrix.pages.dev/usage.html
+This simple example is also available online in the documentation: https://chartjs-chart-matrix.pages.dev/usage/
+
+## Documentation
+
+You can find documentation for chartjs-chart-matrix at [https://chartjs-chart-matrix.pages.dev/](https://chartjs-chart-matrix.pages.dev/). The full configuration reference lives there, not in this README — this file stays a quickstart.
 
 ## Development
 


### PR DESCRIPTION
## Summary

Brings `README.md` to the shared template being rolled out across the `kurkle/*` chart repos: title, badges, one-paragraph description, Example, Installation, Quickstart, Documentation, Development, License.

- **Reorder**: `## Quickstart` now comes before `## Documentation`, so a reader gets install steps and a minimal working example before being pointed to the full docs site.
- **Add `## Installation`**: npm install command and a CDN (`<script>` tag) alternative, which the README was missing.
- **Badge row**: unchanged. It already carries npm, release, bundle size, Quality Gate, Coverage, documentation and a GitHub license badge — see verification note below, this repo was not actually missing the license badge.
- **`## Documentation`**: now says explicitly that the configuration reference lives on the docs site, not in this file, so it doesn't get copied back in later.
- **Fixed a stale link**: the Quickstart's "also available online" link pointed at `.../usage.html`, which 404s since the docs site moved to Starlight. Repointed to `.../usage/` (verified 200).
- Moved the one-line tagline to sit after the badge row as the one-paragraph description, and expanded it slightly to say what the chart type is for (heatmaps, confusion matrices, calendars, etc.) per the shared template.

Quickstart's chart config itself is unchanged — it was verified to already match the live docs sample (`docs/samples/usage.md`), see test plan.

## Test plan

- [x] `npm test` — 29 unit specs, 20 fixture specs (Chrome+Firefox), 2 browser-module integration specs, plus node-commonjs/node-module integration — all green.
- [x] `npm run lint`, `npm run build`, `npm run docs` (pre-commit hook) — all pass; docs build produced the expected static routes.
- [x] Quickstart code block diffed against `docs/samples/usage.md` (the live sample source Astro serves for the same config): identical chart config, only cosmetic differences (trailing commas/semicolons). Left untouched as instructed.
- [x] Every badge fetched and checked for a real value (not "unknown"): npm v3.0.8, release v3.0.8, Quality Gate "passed", Coverage 96.4%, documentation static badge, license MIT. `npm bundle size` returned "rate limited by upstream service" — known, already accepted (bundlephobia rate limiting), not a regression.
- [x] Every link in the README fetched: npm page returns 403 to curl (npmjs.com blocks non-browser requests generically, not a broken link — the npm badge itself confirms the package resolves), GitHub releases/latest redirects to the current tag, docs site root and `/usage/` return 200, MIT license page returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)