### PR TITLE
docs: drop deprecated z import from content.config.ts

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,13 +4,11 @@
 import { docsLoader } from '@astrojs/starlight/loaders'
 import { docsSchema } from '@astrojs/starlight/schema'
 
-import { defineCollection, z } from 'astro:content'
+import { defineCollection } from 'astro:content'
 
 const docs = defineCollection({
   loader: docsLoader(),
-  schema: docsSchema({
-    extend: z.object({}),
-  }),
+  schema: docsSchema(),
 })
 
 export const collections = { docs }


### PR DESCRIPTION
## Summary

`src/content.config.ts` imported `z` from `astro:content`, which is only re-exported there for backward compatibility and is going away:

```ts
import { defineCollection, z } from 'astro:content'
```

Its only use in this file was `docsSchema({ extend: z.object({}) })` — extending the collection schema with an empty object, which is a no-op. So this wasn't just an import that will break later; it was dead code wrapped around a soon-to-be-removed import.

```diff
-import { defineCollection, z } from 'astro:content'
+import { defineCollection } from 'astro:content'

 const docs = defineCollection({
   loader: docsLoader(),
-  schema: docsSchema({
-    extend: z.object({}),
-  }),
+  schema: docsSchema(),
 })
```

`defineCollection` still comes from `astro:content` — only `z`'s re-export is deprecated, and this file doesn't touch anything else. Both `/// <reference ...>` lines at the top of the file are untouched.

## Verifying the deprecation claim independently

Read `node_modules/astro/templates/content/module.mjs` (the actual runtime module `astro:content` resolves to) directly:

```js
// TODO: remove in Astro 8
export { z } from 'astro/zod';
```

Confirms the deprecation is real and comes from Astro itself, not just an assumption.

## A gap in the requested proof, reported honestly

The task asked me to confirm `astro check` runs clean with no deprecation warning about this specific import. I checked both before and after the change (`git stash` to go back to the pre-change file, ran `astro check`, then restored): **`astro check` (astro 7.2.10) reports 0 errors / 0 warnings / 0 hints in both states.** Digging further, Astro's own `// TODO: remove in Astro 8` above the `z` re-export is a plain comment, not a `@deprecated` JSDoc tag, so no diagnostic tool currently surfaces it — not in `astro check`, and not in a plain editor hover either, as far as I can tell from the source. So I can't demonstrate "a warning disappeared", because none appeared in the first place with this Astro version. The change is still correct — it matches Astro's own stated intent and removes genuinely dead code — but that specific proof doesn't apply here. Flagging this in case it matters for the sankey/treemap follow-ups, since the same will be true there unless they're on a newer Astro version that added the JSDoc tag.

## An unrelated lint fix needed to land this

Biome's `assist/source/organizeImports` rejected the suggested one-line, no-blank-line form (`import { docsLoader } ... \nimport { docsSchema } ...\nimport { defineCollection } from 'astro:content'` with no gap) — it requires a blank line separating the `@astrojs/*` import group from the `astro:content` one, same as the original file had. Restored that blank line so `npm run lint` (`biome check`) passes as committed.

## Test plan

- [x] `npm run typecheck:docs` (`astro check`) — 0 errors / 0 warnings / 0 hints (see caveat above: same result before this change too).
- [x] `npm run docs` (`astro build`) — 11 pages built, same count as before the change.
- [x] `npm test` — 29 unit specs, 20 fixture specs (Chrome+Firefox), 2 browser-module integration specs, node-commonjs/node-module integration — all green (also re-ran via the repo's pre-commit hook on commit).
- [x] `npm run lint` (`biome check`) — clean.

## Scope

Only `src/content.config.ts`. No other deprecations found while in this file, no changes to sankey or treemap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)