### PR TITLE
docs: point ecosystem links at sibling package sites

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -65,7 +65,7 @@ export default defineConfig({
             },
             {
               label: 'chartjs-chart-sankey',
-              link: 'https://github.com/kurkle/chartjs-chart-sankey',
+              link: 'https://chartjs-chart-sankey.pages.dev/',
             },
             {
               label: 'chartjs-chart-treemap',
@@ -73,11 +73,11 @@ export default defineConfig({
             },
             {
               label: 'chartjs-plugin-autocolors',
-              link: 'https://github.com/kurkle/chartjs-plugin-autocolors',
+              link: 'https://chartjs-plugin-autocolors.pages.dev/',
             },
             {
               label: 'chartjs-plugin-gradient',
-              link: 'https://github.com/kurkle/chartjs-plugin-gradient',
+              link: 'https://chartjs-plugin-gradient.pages.dev/',
             },
           ],
           label: 'Ecosystem',


### PR DESCRIPTION
## Summary

Updates the three `Ecosystem` sidebar links in `astro.config.mjs` that still pointed at GitHub repos for sibling packages, now that those packages have their own docs sites:

| Label | Before | After |
| --- | --- | --- |
| chartjs-chart-sankey | `https://github.com/kurkle/chartjs-chart-sankey` | `https://chartjs-chart-sankey.pages.dev/` |
| chartjs-plugin-autocolors | `https://github.com/kurkle/chartjs-plugin-autocolors` | `https://chartjs-plugin-autocolors.pages.dev/` |
| chartjs-plugin-gradient | `https://github.com/kurkle/chartjs-plugin-gradient` | `https://chartjs-plugin-gradient.pages.dev/` |

Unchanged, as instructed:
- `chartjs-chart-treemap` already points at its `pages.dev` site.
- `Awesome Chart.js` stays on GitHub — it's a GitHub repo/list, not a package with its own site — and keeps its `rel="noopener noreferrer" target="_blank"` attributes, which the other three entries don't have and shouldn't gain.

Nothing else in the sidebar, README, or content pages touched — grepped the repo for the three old GitHub URLs elsewhere (`.md`, `.mdx`, `.astro`, `.mjs`, `.json`) and found no other references to update or flag.

## Proof

**Every changed URL, plus the two left alone, resolves with 200** (checked individually, not assumed):

| URL | HTTP status |
| --- | --- |
| `https://chartjs-chart-sankey.pages.dev/` | 200 |
| `https://chartjs-plugin-autocolors.pages.dev/` | 200 |
| `https://chartjs-plugin-gradient.pages.dev/` | 200 |
| `https://chartjs-chart-treemap.pages.dev/` (unchanged) | 200 |
| `https://github.com/chartjs/awesome` (unchanged) | 200 |

**Built HTML, not just source config** — ran `npm run docs` and grepped `dist/docs/index.html` (the sidebar is shared across all pages via the Starlight layout, also spot-checked on `dist/docs/usage/index.html`):

```
<a href="https://chartjs-chart-sankey.pages.dev/" class="astro-rmhv4bp6">
<a href="https://chartjs-plugin-autocolors.pages.dev/" class="astro-rmhv4bp6">
<a href="https://chartjs-plugin-gradient.pages.dev/" class="astro-rmhv4bp6">
<a href="https://chartjs-chart-treemap.pages.dev/" ...>
<a href="https://github.com/chartjs/awesome" class="astro-rmhv4bp6" rel="noopener noreferrer" target="_blank">
```

Confirmed no leftover `href="https://github.com/kurkle/chartjs-chart-sankey"` (or the autocolors/gradient equivalents) anywhere in the built output, and that the `rel`/`target` attributes are present only on the Awesome Chart.js anchor.

## Test plan

- [x] `npm run docs` (`astro build`) — 11 pages built, same count as before.
- [x] `npm test` — 29 unit specs, 20 fixture specs (Chrome+Firefox), 2 browser-module integration specs, node-commonjs/node-module integration — all green (also re-ran via the repo's pre-commit hook on commit).
- [x] `npm run lint` (`biome check`) — clean.

## Scope

Only the `Ecosystem` block in `astro.config.mjs`. No other sidebar sections, README, or content pages touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)