### PR TITLE
ci: move Cloudflare Pages docs deploy to shared workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -24,6 +24,9 @@ jobs:
       id-token: write # to enable use of OIDC for npm provenance
       issues: write # to be able to comment on released issues
       pull-requests: write # to be able to comment on released pull requests
+    outputs:
+      released: ${{ steps.release-version.outputs.released }}
+      version: ${{ steps.release-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -54,35 +57,15 @@ jobs:
           echo "released=true" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved released version: $VERSION"
-      - name: Update Cloudflare Pages production docs version
-        if: steps.release-version.outputs.released == 'true'
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
-          DOCS_VERSION: ${{ steps.release-version.outputs.version }}
-        run: |
-          curl --fail --silent --show-error \
-            --request PATCH \
-            --url "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${CLOUDFLARE_PAGES_PROJECT}" \
-            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            --header 'Content-Type: application/json' \
-            --data @- <<EOF
-          {
-            "deployment_configs": {
-              "production": {
-                "env_vars": {
-                  "DOCS_VERSION": {
-                    "type": "plain_text",
-                    "value": "${DOCS_VERSION}"
-                  }
-                }
-              }
-            }
-          }
-          EOF
-      - name: Trigger Cloudflare Pages production deploy
-        if: steps.release-version.outputs.released == 'true'
-        env:
-          CLOUDFLARE_PAGES_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}
-        run: curl --fail --silent --show-error --request POST "$CLOUDFLARE_PAGES_DEPLOY_HOOK"
+
+  docs-deploy:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    uses: kurkle/configs/.github/workflows/docs-deploy.yml@v1
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
+      CLOUDFLARE_PAGES_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}


### PR DESCRIPTION
## Summary

Moves the Cloudflare Pages docs-promotion steps out of `main-ci.yml`'s `release` job and into `@kurkle/configs`' new reusable workflow, `docs-deploy.yml@v1`, per that repo's README `## Docs deploy workflow` section (read from source: `gh api repos/kurkle/configs/contents/README.md`, not just relayed from the task description).

**Only the two Cloudflare steps move.** The `release` job itself, and specifically the `npx --no-install semantic-release` step, stays exactly where it is, in `main-ci.yml`. npm's trusted publishing binds the publisher identity to the exact workflow **file** that runs `semantic-release` — moving that call into a called workflow would break npm publishing fleet-wide. This PR doesn't touch that.

Three changes to the `release` job, all matching the configs README exactly:

1. Added a job-level `outputs:` block (`released`, `version`), next to `permissions:`, before `steps:` — these were previously only outputs of the job's own `release-version` step and weren't visible to a dependent job.
2. Removed the `Update Cloudflare Pages production docs version` and `Trigger Cloudflare Pages production deploy` steps (they moved into `docs-deploy.yml`). `Resolve released version` (`id: release-version`) stays — it reads the git tag and belongs with the release, not the deploy.
3. Added a new `docs-deploy` job: `needs: release`, `if: needs.release.outputs.released == 'true'`, calls `kurkle/configs/.github/workflows/docs-deploy.yml@v1` — a **git ref**, not the npm package version (the npm version of `@kurkle/configs` is irrelevant here) — with the four Cloudflare secrets named explicitly rather than `secrets: inherit`, same reasoning as `SONAR_TOKEN` elsewhere in this file: `inherit` would hand the called workflow every secret this repo has, including `NPM_TOKEN`, for a workflow that has nothing to do with npm.

## Verified independently before making the change

- `gh api repos/kurkle/configs/git/refs/tags/v1` → tag `v1` points at commit `9bbe1031068713980460e2707f9a7e2176a1f6f5`.
- `gh api repos/kurkle/configs/git/refs/heads/main` → `main` is at the same commit. The tag is current, not stale.
- `gh api "repos/kurkle/configs/contents/.github/workflows/docs-deploy.yml?ref=v1"` → the file exists at that ref.
- Fetched and read the actual file content at `v1`: its `workflow_call` declares `inputs.version` (required string) and the four secrets (`CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_PAGES_PROJECT`, `CLOUDFLARE_PAGES_DEPLOY_HOOK`, all required) exactly matching what this PR wires up, and its two steps are a byte-for-byte match (module for module — same `curl` calls, same env var names) for the two steps removed from `main-ci.yml` here.

## Proof

- **`actionlint .github/workflows/main-ci.yml`** → clean, exit code 0. Also ran `actionlint .github/workflows/*.yml` (all workflows in the repo) → clean.
- **YAML validated** with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/main-ci.yml'))"` → parses, and the three top-level jobs (`shared-ci`, `release`, `docs-deploy`) are exactly the ones expected.
- **Line count**: `main-ci.yml` went from **88 lines to 71 lines** (`git diff --stat`: +15/−32).
- **`Resolve released version` and `npx --no-install semantic-release` are still in the same job, in this same file** — confirmed with `grep -n "Resolve released version\|npx --no-install semantic-release\|id: release-version" .github/workflows/main-ci.yml`, both present, both still inside the `release` job.
- Confirmed the four `CLOUDFLARE_*` secret references now appear **only** in the new `docs-deploy` job's `secrets:` block — nowhere else in `.github/workflows/`.

## What this cannot verify before an actual release

`needs.release.outputs.released`/`needs.release.outputs.version` wiring, and the `docs-deploy` job's actual call into `docs-deploy.yml@v1` (including whether the four Cloudflare secrets are configured correctly and whether the Cloudflare API calls themselves succeed), can only be exercised by GitHub Actions running this workflow for real — there is no local runner for a `workflow_call` invocation with real secrets. This will only be proven the next time semantic-release actually cuts a release and tags `HEAD` on `main`. `actionlint` confirms the YAML is well-formed and the `uses:`/`with:`/`secrets:` shapes match what `docs-deploy.yml@v1` declares, but not that the run will succeed end to end.

## Scope

Only `.github/workflows/main-ci.yml`. `pr-ci.yml` untouched, nothing else in the repo touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
