### PR TITLE
chore: run build during prepack so release banner gets real version

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "lint": "biome check",
     "predocs": "npm run docs:version",
     "predocs:dev": "npm run docs:version",
+    "prepack": "npm run build",
     "prepare": "git config core.hooksPath .githooks || true",
     "pretest:unit": "swc --config-file .swcrc-spec src -d build",
     "test": "npm run test:unit && npm run test:fixture && npm run test:integration:browser-module && npm run test:integration:node-commonjs && npm run test:integration:node-module",


### PR DESCRIPTION
## Summary
- Add `"prepack": "npm run build"` to `package.json` scripts.
- `npm publish` runs `prepack` right before packing the tarball — after `semantic-release` has already rewritten `package.json`'s version. Rebuilding at that point means rollup's version banner picks up the real release version instead of the `0.0.0-development` placeholder that's still in `package.json` when `main-ci.yml`'s earlier `npm run build` step runs.
- Matches the existing `chartjs-chart-sankey` package, whose published bundles already carry the correct version banner via this same script.
- No other files changed: `main-ci.yml`, `.releaserc.json`, and the rollup config are untouched.

## Test plan
- [x] `npm run lint`
- [x] `npm test` (unit, fixture, browser/node integration)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run docs`
- [x] `npm run typecheck:docs`
- [x] Targeted check: temporarily set `version` to `9.9.9`, ran `npm pack`, confirmed the log shows `prepack` invoking `npm run build` before the tarball is written, extracted the tarball and confirmed `dist/*.js` banners read `chartjs-chart-matrix v9.9.9`. Reverted `version` back to `0.0.0-development` before committing (not included in the diff).