### PR TITLE
docs: restructure samples so the config tab shows real configuration

### DIFF
--- a/docs/styles/starlight.css
+++ b/docs/styles/starlight.css
@@ -1,3 +1,15 @@
+:root {
+  --sl-content-width: 52rem;
+  --sl-text-h1: 2rem;
+  --sl-text-h2: 1.5rem;
+  --sl-text-h3: 1.25rem;
+  --sl-text-h4: 1.125rem;
+}
+
+.content-panel {
+  padding-block: 1rem;
+}
+
 @layer starlight.overrides {
   .site-title {
     display: inline-flex;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@biomejs/biome": "^2.4.14",
         "@emnapi/core": "^1.11.2",
         "@emnapi/runtime": "^1.11.2",
-        "@kurkle/astro-chartjs-editor": "^1.0.0",
+        "@kurkle/astro-chartjs-editor": "^1.3.1",
         "@kurkle/configs": "^1.5.1",
         "@napi-rs/canvas": "^1.0.0",
         "@rollup/plugin-commonjs": "^29.0.0",
@@ -2498,15 +2498,20 @@
       }
     },
     "node_modules/@kurkle/astro-chartjs-editor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@kurkle/astro-chartjs-editor/-/astro-chartjs-editor-1.0.0.tgz",
-      "integrity": "sha512-/KBCKYV9+OmQrKWRz/n2+q+rAahGnw5TddFfAa3Z/VwXpL7NtMPDOsnejZVsI9sogxKOwD1U2K5g8H1TlwIbuA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@kurkle/astro-chartjs-editor/-/astro-chartjs-editor-1.3.1.tgz",
+      "integrity": "sha512-76QYNJ8d+ZSq2PeuLVEwGmRCDgijKwBU3aKKrd/JLd7VOO5z1Sd67rJC3NMVAatfK6a6c2m4Rxvw7A5GZBaHEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",
+        "@codemirror/state": "^6.7.4",
         "@codemirror/theme-one-dark": "^6.1.3",
+        "@codemirror/view": "^6.43.11",
         "codemirror": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
         "astro": "^5.0.0 || ^6.0.0 || ^7.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@biomejs/biome": "^2.4.14",
     "@emnapi/core": "^1.11.2",
     "@emnapi/runtime": "^1.11.2",
-    "@kurkle/astro-chartjs-editor": "^1.0.0",
+    "@kurkle/astro-chartjs-editor": "^1.3.1",
     "@kurkle/configs": "^1.5.1",
     "@napi-rs/canvas": "^1.0.0",
     "@rollup/plugin-commonjs": "^29.0.0",

--- a/src/content/docs/samples/basic.md
+++ b/src/content/docs/samples/basic.md
@@ -5,20 +5,29 @@ description: Basic matrix sample on a linear scale.
 
 ```js chart-editor title="Basic (Linear Scale)"
 // <block:data:1>
-const data = {
-  datasets: [{
-    label: 'My Matrix',
-    data: [
-      {x: 1, y: 1, v: 11},
-      {x: 1, y: 2, v: 12},
-      {x: 1, y: 3, v: 13},
-      {x: 2, y: 1, v: 21},
-      {x: 2, y: 2, v: 22},
-      {x: 2, y: 3, v: 23},
-      {x: 3, y: 1, v: 31},
-      {x: 3, y: 2, v: 32},
-      {x: 3, y: 3, v: 33}
-    ],
+const points = [
+  {x: 1, y: 1, v: 11},
+  {x: 1, y: 2, v: 12},
+  {x: 1, y: 3, v: 13},
+  {x: 2, y: 1, v: 21},
+  {x: 2, y: 2, v: 22},
+  {x: 2, y: 3, v: 23},
+  {x: 3, y: 1, v: 31},
+  {x: 3, y: 2, v: 32},
+  {x: 3, y: 3, v: 33}
+];
+// </block:data>
+
+// <block:config:0>
+const config = {
+  type: 'matrix',
+  data: {
+    datasets: [{
+      label: 'My Matrix',
+      data: points
+    }]
+  },
+  options: {
     backgroundColor(context) {
       const value = context.dataset.data[context.dataIndex].v;
       const alpha = (value - 5) / 40;
@@ -31,17 +40,7 @@ const data = {
     },
     borderWidth: 1,
     width: ({chart}) => (chart.chartArea || {}).width / 3 - 1,
-    height: ({chart}) =>(chart.chartArea || {}).height / 3 - 1
-  }]
-};
-// </block:data>
-
-
-// <block:config:0>
-const config = {
-  type: 'matrix',
-  data: data,
-  options: {
+    height: ({chart}) =>(chart.chartArea || {}).height / 3 - 1,
     plugins: {
       legend: false,
       tooltip: {
@@ -77,7 +76,6 @@ const config = {
     }
   }
 };
-
 // </block:config>
 
 const actions = [

--- a/src/content/docs/samples/calendar.md
+++ b/src/content/docs/samples/calendar.md
@@ -4,7 +4,7 @@ description: Matrix sample rendered as a calendar heatmap on a time scale.
 ---
 
 ```js chart-editor title="Calendar (Time Scale)"
-// <block:generate:4>
+// <block:generate:2>
 function generateData() {
   const adapter = new helpers._adapters._date();
   const data = [];
@@ -24,10 +24,19 @@ function generateData() {
 }
 // </block:generate>
 
-// <block:data:2>
+// <block:data:1>
 const data = {
   datasets: [{
-    data: generateData(),
+    data: generateData()
+  }]
+};
+// </block:data>
+
+// <block:config:0>
+const config = {
+  type: 'matrix',
+  data: data,
+  options: {
     backgroundColor({raw}) {
       const alpha = (10 + raw.v) / 60;
       return helpers.color('green').alpha(alpha).rgbString();
@@ -40,98 +49,82 @@ const data = {
     hoverBackgroundColor: 'yellow',
     hoverBorderColor: 'yellowgreen',
     width: ({chart}) => (chart.chartArea || {}).width / chart.scales.x.ticks.length - 3,
-    height: ({chart}) =>(chart.chartArea || {}).height / chart.scales.y.ticks.length - 3
-  }]
-};
-// </block:data>
-
-// <block:scales:3>
-const scales = {
-  y: {
-    type: 'time',
-    left: 'left',
-    offset: true,
-    time: {
-      unit: 'week',
-      round: 'week',
-      isoWeekday: 1,
-      displayFormats: {
-        week: 'I'
-      }
+    height: ({chart}) =>(chart.chartArea || {}).height / chart.scales.y.ticks.length - 3,
+    plugins: {
+      legend: false,
+      tooltip: {
+        displayColors: false,
+        callbacks: {
+          title() {
+            return '';
+          },
+          label(context) {
+            const v = context.dataset.data[context.dataIndex];
+            return ['d: ' + v.d, 'v: ' + v.v.toFixed(2)];
+          }
+        }
+      },
     },
-    ticks: {
-      maxRotation: 0,
-      autoSkip: true,
-      padding: 1
-    },
-    grid: {
-      display: false,
-      drawBorder: false,
-      tickLength: 0,
-    },
-    title: {
-      display: true,
-      font: {size: 15, weigth: 'bold'},
-      text: ({chart}) => chart.scales.x._adapter.format(Date.now(), 'MMM, yyyy'),
-      padding: 0
-    }
-  },
-  x: {
-    type: 'time',
-    position: 'top',
-    offset: true,
-    time: {
-      unit: 'day',
-      parser: 'i',
-      isoWeekday: 1,
-      displayFormats: {
-        day: 'iiiiii'
-      }
-    },
-    reverse: false,
-    ticks: {
-      source: 'data',
-      padding: 0,
-      maxRotation: 0,
-    },
-    grid: {
-      display: false,
-      drawBorder: false,
-    }
-  }
-};
-// </block:scales>
-
-// <block:options:1>
-const options = {
-  plugins: {
-    legend: false,
-    tooltip: {
-      displayColors: false,
-      callbacks: {
-        title() {
-          return '';
+    scales: {
+      y: {
+        type: 'time',
+        left: 'left',
+        offset: true,
+        time: {
+          unit: 'week',
+          round: 'week',
+          isoWeekday: 1,
+          displayFormats: {
+            week: 'I'
+          }
         },
-        label(context) {
-          const v = context.dataset.data[context.dataIndex];
-          return ['d: ' + v.d, 'v: ' + v.v.toFixed(2)];
+        ticks: {
+          maxRotation: 0,
+          autoSkip: true,
+          padding: 1
+        },
+        grid: {
+          display: false,
+          drawBorder: false,
+          tickLength: 0,
+        },
+        title: {
+          display: true,
+          font: {size: 15, weigth: 'bold'},
+          text: ({chart}) => chart.scales.x._adapter.format(Date.now(), 'MMM, yyyy'),
+          padding: 0
+        }
+      },
+      x: {
+        type: 'time',
+        position: 'top',
+        offset: true,
+        time: {
+          unit: 'day',
+          parser: 'i',
+          isoWeekday: 1,
+          displayFormats: {
+            day: 'iiiiii'
+          }
+        },
+        reverse: false,
+        ticks: {
+          source: 'data',
+          padding: 0,
+          maxRotation: 0,
+        },
+        grid: {
+          display: false,
+          drawBorder: false,
         }
       }
     },
-  },
-  scales: scales,
-  layout: {
-    padding: {
-      top: 10,
+    layout: {
+      padding: {
+        top: 10,
+      }
     }
   }
-};
-// </block:options>
-// <block:config:0>
-const config = {
-  type: 'matrix',
-  data: data,
-  options: options
 };
 // </block:config>
 

--- a/src/content/docs/samples/category.md
+++ b/src/content/docs/samples/category.md
@@ -5,20 +5,29 @@ description: Matrix sample using category scales on both axes.
 
 ```js chart-editor title="Category Scale"
 // <block:data:1>
-const data = {
-  datasets: [{
-    label: 'My Matrix',
-    data: [
-      {x: 'A', y: 'X', v: 11},
-      {x: 'A', y: 'Y', v: 12},
-      {x: 'A', y: 'Z', v: 13},
-      {x: 'B', y: 'X', v: 21},
-      {x: 'B', y: 'Y', v: 22},
-      {x: 'B', y: 'Z', v: 23},
-      {x: 'C', y: 'X', v: 31},
-      {x: 'C', y: 'Y', v: 32},
-      {x: 'C', y: 'Z', v: 33}
-    ],
+const points = [
+  {x: 'A', y: 'X', v: 11},
+  {x: 'A', y: 'Y', v: 12},
+  {x: 'A', y: 'Z', v: 13},
+  {x: 'B', y: 'X', v: 21},
+  {x: 'B', y: 'Y', v: 22},
+  {x: 'B', y: 'Z', v: 23},
+  {x: 'C', y: 'X', v: 31},
+  {x: 'C', y: 'Y', v: 32},
+  {x: 'C', y: 'Z', v: 33}
+];
+// </block:data>
+
+// <block:config:0>
+const config = {
+  type: 'matrix',
+  data: {
+    datasets: [{
+      label: 'My Matrix',
+      data: points
+    }]
+  },
+  options: {
     backgroundColor(context) {
       const value = context.dataset.data[context.dataIndex].v;
       const alpha = (value - 5) / 40;
@@ -31,16 +40,7 @@ const data = {
     },
     borderWidth: 1,
     width: ({chart}) => (chart.chartArea || {}).width / 3 - 1,
-    height: ({chart}) =>(chart.chartArea || {}).height / 3 - 1
-  }]
-};
-// </block:data>
-
-// <block:config:0>
-const config = {
-  type: 'matrix',
-  data: data,
-  options: {
+    height: ({chart}) =>(chart.chartArea || {}).height / 3 - 1,
     plugins: {
       legend: false,
       tooltip: {

--- a/src/content/docs/samples/time.md
+++ b/src/content/docs/samples/time.md
@@ -4,7 +4,7 @@ description: Matrix sample plotting a full year of daily values on a time scale.
 ---
 
 ```js chart-editor title="On Time Scale"
-// <block:generate:4>
+// <block:generate:2>
 function generateData() {
   const data = [];
   const end = Utils.startOfToday();
@@ -23,11 +23,21 @@ function generateData() {
 }
 // </block:generate>
 
-// <block:data:2>
+// <block:data:1>
 const data = {
   datasets: [{
     label: 'My Matrix',
-    data: generateData(),
+    data: generateData()
+  }]
+};
+// </block:data>
+
+// <block:config:0>
+const config = {
+  type: 'matrix',
+  data: data,
+  options: {
+    aspectRatio: 5,
     backgroundColor(c) {
       const value = c.dataset.data[c.dataIndex].v;
       const alpha = (10 + value) / 60;
@@ -48,101 +58,83 @@ const data = {
     height(c) {
       const a = c.chart.chartArea || {};
       return (a.bottom - a.top) / 7 - 1;
-    }
-  }]
-};
-// </block:data>
-
-// <block:scales:3>
-const scales = {
-  y: {
-    type: 'time',
-    offset: true,
-    time: {
-      unit: 'day',
-      round: 'day',
-      isoWeekday: 1,
-      parser: 'i',
-      displayFormats: {
-        day: 'iiiiii'
-      }
     },
-    reverse: true,
-    position: 'right',
-    ticks: {
-      maxRotation: 0,
-      autoSkip: true,
-      padding: 1,
-      font: {
-        size: 9
-      }
+    plugins: {
+      legend: false,
+      tooltip: {
+        displayColors: false,
+        callbacks: {
+          title() {
+            return '';
+          },
+          label(context) {
+            const v = context.dataset.data[context.dataIndex];
+            return ['d: ' + v.d, 'v: ' + v.v.toFixed(2)];
+          }
+        }
+      },
     },
-    grid: {
-      display: false,
-      drawBorder: false,
-      tickLength: 0
-    }
-  },
-  x: {
-    type: 'time',
-    position: 'bottom',
-    offset: true,
-    time: {
-      unit: 'week',
-      round: 'week',
-      isoWeekday: 1,
-      displayFormats: {
-        week: 'MMM dd'
-      }
-    },
-    ticks: {
-      maxRotation: 0,
-      autoSkip: true,
-      font: {
-        size: 9
-      }
-    },
-    grid: {
-      display: false,
-      drawBorder: false,
-      tickLength: 0,
-    }
-  }
-};
-// </block:scales>
-
-// <block:options:1>
-const options = {
-  aspectRatio: 5,
-  plugins: {
-    legend: false,
-    tooltip: {
-      displayColors: false,
-      callbacks: {
-        title() {
-          return '';
+    scales: {
+      y: {
+        type: 'time',
+        offset: true,
+        time: {
+          unit: 'day',
+          round: 'day',
+          isoWeekday: 1,
+          parser: 'i',
+          displayFormats: {
+            day: 'iiiiii'
+          }
         },
-        label(context) {
-          const v = context.dataset.data[context.dataIndex];
-          return ['d: ' + v.d, 'v: ' + v.v.toFixed(2)];
+        reverse: true,
+        position: 'right',
+        ticks: {
+          maxRotation: 0,
+          autoSkip: true,
+          padding: 1,
+          font: {
+            size: 9
+          }
+        },
+        grid: {
+          display: false,
+          drawBorder: false,
+          tickLength: 0
+        }
+      },
+      x: {
+        type: 'time',
+        position: 'bottom',
+        offset: true,
+        time: {
+          unit: 'week',
+          round: 'week',
+          isoWeekday: 1,
+          displayFormats: {
+            week: 'MMM dd'
+          }
+        },
+        ticks: {
+          maxRotation: 0,
+          autoSkip: true,
+          font: {
+            size: 9
+          }
+        },
+        grid: {
+          display: false,
+          drawBorder: false,
+          tickLength: 0,
         }
       }
     },
-  },
-  scales: scales,
-  layout: {
-    padding: {
-      top: 10
+    layout: {
+      padding: {
+        top: 10
+      }
     }
   }
-};
-// </block:options>
-
-// <block:config:0>
-const config = {
-  type: 'matrix',
-  data: data,
-  options: options
 };
 // </block:config>
 

--- a/src/content/docs/samples/yearweek.md
+++ b/src/content/docs/samples/yearweek.md
@@ -4,8 +4,8 @@ title: Year Week
 description: Year-week heatmap spanning a decade of ISO weeks.
 ---
 
-```js chart-editor title="Year Week"
-// <block:generate:4>
+```js chart-editor
+// <block:generate:2>
 function generateData() {
   const adapter = new helpers._adapters._date();
   const data = [];
@@ -38,10 +38,20 @@ function generateData() {
 }
 // </block:generate>
 
-// <block:data:2>
+// <block:data:1>
 const data = {
   datasets: [{
-    data: generateData(),
+    data: generateData()
+  }]
+};
+// </block:data>
+
+// <block:config:0>
+const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const config = {
+  type: 'matrix',
+  data: data,
+  options: {
     backgroundColor({raw}) {
       const alpha = (10 + raw.v) / 60;
       return helpers.color('green').alpha(alpha).rgbString();
@@ -54,96 +64,78 @@ const data = {
     hoverBackgroundColor: 'yellow',
     hoverBorderColor: 'yellowgreen',
     width: 10,
-    height: ({chart}) =>(chart.chartArea || {}).height / chart.scales.y.ticks.length - 3
-  }]
-};
-// </block:data>
-
-// <block:scales:3>
-const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-const scales = {
-  y: {
-    type: 'time',
-    left: 'left',
-    offset: true,
-    time: {
-      unit: 'year',
-      round: 'year',
-      displayFormats: {
-        parsing: 'yyyy',
-        year: 'R' // ISO week-numbering year
-      }
+    height: ({chart}) =>(chart.chartArea || {}).height / chart.scales.y.ticks.length - 3,
+    plugins: {
+      legend: false,
+      tooltip: {
+        displayColors: false,
+        callbacks: {
+          title() {
+            return '';
+          },
+          label({raw}) {
+            return ['w: ' + raw.w, 'isoWeek: ' + raw.iw, 'v: ' + raw.v.toFixed(2)];
+          }
+        }
+      },
     },
-    ticks: {
-      maxRotation: 0,
-      autoSkip: false,
-      padding: 1
-    },
-    grid: {
-      display: false,
-      drawBorder: false,
-      tickLength: 0,
-    },
-    title: {
-      display: true,
-      font: {size: 15, weigth: 'bold'},
-      text: 'Year',
-      padding: 0
-    }
-  },
-  x: {
-    type: 'linear',
-    position: 'top',
-    offset: true,
-    min: 1,
-    max: 72,
-    reverse: false,
-    ticks: {
-      autoSkip: false,
-      callback: (val, index) => val % 6 === 3 ? months[(val - 3) / 6] : '',
-      maxTicksLimit: 100,
-      stepSize: 1,
-      padding: 0,
-      maxRotation: 0,
-    },
-    grid: {
-      display: false,
-      drawBorder: false,
-    }
-  }
-};
-// </block:scales>
-
-// <block:options:1>
-const options = {
-  plugins: {
-    legend: false,
-    tooltip: {
-      displayColors: false,
-      callbacks: {
-        title() {
-          return '';
+    scales: {
+      y: {
+        type: 'time',
+        left: 'left',
+        offset: true,
+        time: {
+          unit: 'year',
+          round: 'year',
+          displayFormats: {
+            parsing: 'yyyy',
+            year: 'R' // ISO week-numbering year
+          }
         },
-        label({raw}) {
-          return ['w: ' + raw.w, 'isoWeek: ' + raw.iw, 'v: ' + raw.v.toFixed(2)];
+        ticks: {
+          maxRotation: 0,
+          autoSkip: false,
+          padding: 1
+        },
+        grid: {
+          display: false,
+          drawBorder: false,
+          tickLength: 0,
+        },
+        title: {
+          display: true,
+          font: {size: 15, weigth: 'bold'},
+          text: 'Year',
+          padding: 0
+        }
+      },
+      x: {
+        type: 'linear',
+        position: 'top',
+        offset: true,
+        min: 1,
+        max: 72,
+        reverse: false,
+        ticks: {
+          autoSkip: false,
+          callback: (val, index) => val % 6 === 3 ? months[(val - 3) / 6] : '',
+          maxTicksLimit: 100,
+          stepSize: 1,
+          padding: 0,
+          maxRotation: 0,
+        },
+        grid: {
+          display: false,
+          drawBorder: false,
         }
       }
     },
-  },
-  scales: scales,
-  layout: {
-    padding: {
-      top: 10,
+    layout: {
+      padding: {
+        top: 10,
+      }
     }
   }
-};
-// </block:options>
-
-// <block:config:0>
-const config = {
-  type: 'matrix',
-  data: data,
-  options: options
 };
 // </block:config>
 

--- a/src/content/docs/samples/zoom.md
+++ b/src/content/docs/samples/zoom.md
@@ -4,7 +4,7 @@ description: Matrix sample with wheel/pinch zoom and pan via chartjs-plugin-zoom
 ---
 
 ```js chart-editor title="Zoom and Pan"
-// <block:generate:4>
+// <block:generate:2>
 function generateData() {
   const data = [];
 
@@ -22,11 +22,20 @@ function generateData() {
 }
 // </block:generate>
 
-// <block:data:2>
+// <block:data:1>
 const data = {
   datasets: [{
     label: 'My Matrix',
-    data: generateData(),
+    data: generateData()
+  }]
+};
+// </block:data>
+
+// <block:config:0>
+const config = {
+  type: 'matrix',
+  data: data,
+  options: {
     backgroundColor({raw}) {
       const alpha = (10 + raw.v) / 110;
       return helpers.color('green').alpha(alpha).rgbString();
@@ -43,79 +52,66 @@ const data = {
     height({chart}) {
       const y = chart.scales.y;
       return Math.abs(y.getPixelForValue(2) - y.getPixelForValue(1)) - 1;
-    }
-  }]
-};
-// </block:data>
-
-// <block:options:1>
-const options = {
-  plugins: {
-    legend: false,
-    tooltip: {
-      callbacks: {
-        title() {
-          return '';
+    },
+    plugins: {
+      legend: false,
+      tooltip: {
+        callbacks: {
+          title() {
+            return '';
+          },
+          label(context) {
+            const v = context.dataset.data[context.dataIndex];
+            return ['x: ' + v.x, 'y: ' + v.y, 'v: ' + v.v.toFixed(2)];
+          }
+        }
+      },
+      zoom: {
+        limits: {
+          x: {min: 0.5, max: 30.5, minRange: 3},
+          y: {min: 0.5, max: 20.5, minRange: 3}
         },
-        label(context) {
-          const v = context.dataset.data[context.dataIndex];
-          return ['x: ' + v.x, 'y: ' + v.y, 'v: ' + v.v.toFixed(2)];
+        pan: {
+          enabled: true,
+          mode: 'xy'
+        },
+        zoom: {
+          wheel: {
+            enabled: true
+          },
+          pinch: {
+            enabled: true
+          },
+          mode: 'xy'
         }
       }
     },
-    zoom: {
-      limits: {
-        x: {min: 0.5, max: 30.5, minRange: 3},
-        y: {min: 0.5, max: 20.5, minRange: 3}
-      },
-      pan: {
-        enabled: true,
-        mode: 'xy'
-      },
-      zoom: {
-        wheel: {
-          enabled: true
+    scales: {
+      x: {
+        display: false,
+        min: 0.5,
+        max: 30.5,
+        ticks: {
+          stepSize: 1
         },
-        pinch: {
-          enabled: true
+        grid: {
+          display: false
+        }
+      },
+      y: {
+        display: false,
+        min: 0.5,
+        max: 20.5,
+        reverse: true,
+        ticks: {
+          stepSize: 1
         },
-        mode: 'xy'
-      }
-    }
-  },
-  scales: {
-    x: {
-      display: false,
-      min: 0.5,
-      max: 30.5,
-      ticks: {
-        stepSize: 1
-      },
-      grid: {
-        display: false
-      }
-    },
-    y: {
-      display: false,
-      min: 0.5,
-      max: 20.5,
-      reverse: true,
-      ticks: {
-        stepSize: 1
-      },
-      grid: {
-        display: false
+        grid: {
+          display: false
+        }
       }
     }
   }
-};
-// </block:options>
-
-// <block:config:0>
-const config = {
-  type: 'matrix',
-  data: data,
-  options: options
 };
 // </block:config>
 


### PR DESCRIPTION
## Summary
- Bump `@kurkle/astro-chartjs-editor` `^1.0.0` -> `^1.3.1` so the default-visible `config` tab shows the real configuration instead of five lines pointing at other tabs.
- Restructure all seven `src/content/docs/samples/*.md` files: `data` blocks now hold only the plotted points, matrix element options (`backgroundColor`, `borderColor`, `borderWidth`, `hoverBackgroundColor`, `hoverBorderColor`, `width`, `height`) move from the dataset onto chart-level `options`, and the `options`/`scales` support blocks that existed only to keep `config` short are inlined into `config`. Helper `generate` blocks stay separate.
- `docs/styles/starlight.css`: added a `:root` block above the existing `@layer starlight.overrides` block with the heading scale and content-panel padding used by the sibling repos (existing rules untouched).

## Details per file
- `basic.md`, `category.md`: 2 tabs (`config`, `data`), unchanged shape otherwise.
- `calendar.md`, `time.md`, `yearweek.md`, `zoom.md`: previously 5 tabs (`config`, `options`, `data`, `scales`, `generate`); now 3 tabs (`config`, `data`, `generate`). `yearweek.md` also drops the `title="Year Week"` fence attribute since it was a verbatim repeat of the page's h1 and the editor no longer falls back to it; the other six keep their fence titles since they add scale/mode information beyond the plain page h1.
- `utils.mdx`: no chart-editor block, no changes needed.
- No `choices` controls were added. None of these seven pages demonstrate a single option with a small set of visibly-different alternatives (unlike the sankey pilot's `orientation`/`nodePaddingMode`) — the existing `Randomize`/`Reset zoom` actions were kept as-is.

## Verification
- `npm ls @kurkle/astro-chartjs-editor` resolves `1.3.1`.
- `npm run lint` (biome) passes.
- `npm run docs` (rollup+tsc build, then `astro build`) succeeds, generating all 11 pages including the 7 sample pages.
- Served the build with `astro preview` and screenshotted all 6 changed sample pages (`basic`, `calendar`, `category`, `time`, `yearweek`, `zoom`) with Playwright at 1400x900 and 1200x900, reading each `<canvas>` inside the editor's shadow DOM directly (not a copy) and counting non-transparent, non-white pixels:
  - basic: 237732/270686 px @1400, 117643/140896 @1200
  - calendar: 190330/270686 @1400, 91867/140896 @1200
  - category: 237456/270686 @1400, 117472/140896 @1200
  - time: 82492/102531 @1400, 39959/53251 @1200
  - yearweek: 157999/270686 @1400, 82863/140896 @1200
  - zoom: 250032/270686 @1400, 127793/140896 @1200
  All non-blank, zero console/page errors in any of the 12 captures.
- `npm test` passes: unit 29/29, fixture (browser) 20/20, integration browser-module 2/2, node-commonjs and node-module integration scripts, and the 19-check `kurkle-check-package` pack contract.
- `npm run typecheck:docs` (`astro check`): 0 errors, 0 warnings, 0 hints.
- `package-lock.json` diff is limited to the editor bump and its new transitive deps (`@codemirror/state`, `@codemirror/view`).

## Not done / out of scope
- No `choices` controls added (see above — no page in this repo currently demonstrates a good candidate option).
- Did not touch `utils.mdx` (nothing to restructure there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)